### PR TITLE
set default docs to master instead of stable

### DIFF
--- a/src/data/MainSource.js
+++ b/src/data/MainSource.js
@@ -7,7 +7,7 @@ export default new DocsSource({
 	name: 'Main library',
 	global: 'Klasa',
 	repo: 'dirigeants/klasa',
-	defaultTag: 'stable',
+	defaultTag: 'master',
 	branchFilter: branch => {
 		if (/^greenkeeper/g.test(branch)) return false;
 		return !branchBlacklist.has(branch);


### PR DESCRIPTION
99% of the time people come to the docs to read the #master branch docs for the main lib, this saves us from switching from stable to master every time (temporary until major stable release like the warning on the home page).

It also (temporarily) stops people from accidentally looking at the stable docs (not knowing that there is master docs) and seeing a very outdated/incomplete/etc documentation and running in to issues or judging the lib off it.