### PR TITLE
fix inconsistent width on mobile, use different cursor on hover

### DIFF
--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -6,7 +6,7 @@
 			<br>
 			<div class="tile is-ancestor">
 				<b-tooltip
-					class="tile is-parent stable-tile"
+					class="tile is-parent is-flex"
 					label="The stable branch is currently unsupported awaiting a stable discord.js v12 release! Please use the master branch for now."
 					type="is-danger"
 					multilined

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -6,7 +6,7 @@
 			<br>
 			<div class="tile is-ancestor">
 				<b-tooltip
-					class="tile is-parent"
+					class="tile is-parent stable-tile"
 					label="The stable branch is currently unsupported awaiting a stable discord.js v12 release! Please use the master branch for now."
 					type="is-danger"
 					multilined

--- a/src/style.scss
+++ b/src/style.scss
@@ -87,3 +87,8 @@ pre {
 .is-not-feeling-so-good {
 	opacity: 0.3;
 }
+
+.stable-tile {
+	display: flex;
+	cursor: not-allowed;
+}

--- a/src/style.scss
+++ b/src/style.scss
@@ -87,8 +87,3 @@ pre {
 .is-not-feeling-so-good {
 	opacity: 0.3;
 }
-
-.stable-tile {
-	display: flex;
-	cursor: not-allowed;
-}


### PR DESCRIPTION
At smaller sizes, the presence of `inline-flex` on the tooltip container is causing the "stable" tile to not take up the full width of the container like the "master" tile. Using 'flex' instead fixes this, It also now displays the "disabled/not-allowed" cursor on hover